### PR TITLE
Update editor.js to allow for user-specified ID for editor embedding

### DIFF
--- a/cdn/ace/editor.js
+++ b/cdn/ace/editor.js
@@ -11,7 +11,7 @@ themeChuckJS.type = 'text/javascript';
 themeChuckJS.charset = 'utf-8';
 document.head.appendChild(themeChuckJS);
 
-function newChuckEditor(divId, code = "", readonly = false) {
+function newChuckEditor(divId = 'editor', code = "", readonly = false) {
     const editor = ace.edit(divId);
     editor.setTheme('ace/theme/chuck');
     editor.session.setMode('ace/mode/chuck');


### PR DESCRIPTION
The editor script only allows the Ace editor to be loaded in a div with id "editor." The function `newChuckEditor` does have a `divId` parameter, so using that instead. This also allows for multiple editors to be instantiated on the same page.