### PR TITLE
refactor: restructure UI layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 yarn.lock
 dist
 scripts/json
+scripts/deploy

--- a/index.html
+++ b/index.html
@@ -224,57 +224,34 @@
           </div>
 
           <!-- Right -->
-          <!-- More Menu Button-->
           <div class="flex justify-right items-center text-blue-600 dark:text-blue-200 overflow-none">
-            <!-- <button id="moreMenu" type="button" class="block text-dark hover:white focus:text-light focus:outline-none">
-              <svg class="h-7 w-7 fill-current" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="100" height="100" viewBox="0 0 32 32">
-                <path d="M 16 6 C 14.894531 6 14 6.894531 14 8 C 14 9.105469 14.894531 10 16 10 C 17.105469 10 18 9.105469 18 8 C 18 6.894531 17.105469 6 16 6 Z M 16 14 C 14.894531 14 14 14.894531 14 16 C 14 17.105469 14.894531 18 16 18 C 17.105469 18 18 17.105469 18 16 C 18 14.894531 17.105469 14 16 14 Z M 16 22 C 14.894531 22 14 22.894531 14 24 C 14 25.105469 14.894531 26 16 26 C 17.105469 26 18 25.105469 18 24 C 18 22.894531 17.105469 22 16 22 Z"></path>
-              </svg>
-            </button> -->
-            <button id="shareCode" class="button border-2 border-blue-600 dark:border-blue-200 px-3 py-1 rounded-lg font-medium mr-4 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 dark:focus-visible:ring-blue-200">Share</button>
             <b class="w-[122px] text-md">WebChucK IDE </b><b><em class="text-3xl">2</em></b>
+            <button id="shareCode" class="button border-2 border-blue-600 dark:border-blue-200 px-3 py-1 rounded-md font-medium ml-4 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 dark:focus-visible:ring-blue-200">Share</button>
           </div>
         </nav>
       </div>
 
 
       <!-- CHUCK BAR -->
-      <div id="chuck-bar" class="bg-orange-peach dark:bg-dark-4">
-        <div class="w-full h-full flex justify-between items-center px-2 py-1">
-          <!-- left side -->
-          <div id="chuckBarLeft" class="flex justify-left items-center">
-
-            <!-- WebChucK Button-->
-            <button id="webchuckButton" type="button" class="font-semibold bg-orange text-white mr-2 py-2 px-1 max-h-full w-40 md:w-48 2xl:w-64 rounded-md enabled:hover:bg-orange-400 transition-all overflow-hidden truncate disabled:opacity-50" disabled>Loading...</button>
-            <!-- Chuck Buttons -->
-            <div class="flex h-full justify-start items-center">
-              <button id="micButton"      type="button" class="chuck-button" title="Enable Microphone" aria-label="Enable Microphone" disabled>
-                <img src="img/mic.svg" alt="Microphone" class="h-11" draggable="false">
-              </button>
-              <button id="playButton"     type="button" class="chuck-button" aria-label="Play" disabled>
-                <img src="img/play.svg" alt="Play" class="h-11" draggable="false">
-              </button>
-              <button id="replaceButton"  type="button" class="chuck-button" aria-label="Replace" disabled>
-                <img src="img/replace.svg" alt="Replace" class="h-11" draggable="false">
-              </button>
-              <button id="removeButton"   type="button" class="chuck-button" aria-label="Remove" disabled>
-                <img src="img/remove.svg" alt="Remove" class="h-11" draggable="false">
-              </button>
-              <button id="recordButton"   type="button" class="chuck-button" aria-label="Record" disabled>
-                <img id="recordImage" src="img/record-button.svg" alt="Record" class="h-11" draggable="false">
-              </button>
-            </div>
-
+      <div id="chuckBar" class="bg-orange-peach dark:bg-dark-4 flex items-center justify-end px-2 py-1 gap-2">
+          <div class="flex items-center gap-2 flex-shrink-0">
+            <button id="webchuckButton" type="button" class="chuck-button h-10 font-semibold bg-orange text-white text-base px-3 enabled:hover:bg-orange-400 transition-all overflow-hidden truncate disabled:opacity-50" disabled>Loading...</button>
+            <button id="micButton" type="button" class="chuck-button bg-[#CF68FF] disabled:opacity-50" title="Enable Microphone" aria-label="Enable Microphone" disabled>
+              <svg viewBox="13 9 24 33" fill="none" class="w-5 h-5"><path d="M25 10.1667C22.3764 10.1667 20.25 12.2931 20.25 14.9167V24.4167C20.25 27.0402 22.3764 29.1667 25 29.1667C27.6236 29.1667 29.75 27.0402 29.75 24.4167V14.9167C29.75 12.2931 27.6236 10.1667 25 10.1667ZM15.6392 24.4167C14.6797 24.4167 13.9069 25.2681 14.062 26.2165C14.8377 30.966 18.6368 34.6909 23.4167 35.3763V38.6667C23.4167 39.5407 24.126 40.25 25 40.25C25.874 40.25 26.5834 39.5407 26.5834 38.6667V35.3763C31.3632 34.6909 35.1624 30.966 35.938 26.2165C36.0932 25.2681 35.3204 24.4167 34.3609 24.4167C33.5787 24.4167 32.9337 24.9923 32.8023 25.765C32.161 29.4937 28.9124 32.3333 25 32.3333C21.0876 32.3333 17.839 29.4937 17.1978 25.765C17.0664 24.9923 16.4229 24.4167 15.6392 24.4167Z" fill="white"/></svg>
+            </button>
+            <button id="playButton" type="button" class="chuck-button bg-[#70E16E]" aria-label="Play" disabled>
+              <svg viewBox="14 10 28 33" fill="none" class="w-5 h-5"><path d="M40.1084 25.7217L15.9126 39.6911L15.9126 11.7522L40.1084 25.7217Z" fill="white"/><rect x="30.5172" y="35.5744" width="10.4631" height="1.79367" fill="white"/><rect x="34.7024" y="41.8522" width="10.4631" height="1.79367" transform="rotate(-90 34.7024 41.8522)" fill="white"/></svg>
+            </button>
+            <button id="replaceButton" type="button" class="chuck-button bg-[#6abcf8]" aria-label="Replace" disabled>
+              <svg viewBox="7 7 35 34" fill="none" class="w-5 h-5"><path d="M 40.6427,18.1892 C 38.3934,12.9175 33.5504,9.20644 27.8752,8.40558 22.1999,7.60471 16.5191,9.83074 12.8989,14.2741 L 9.40522,12.2004 9.34591,12.1864 C 9.28649,12.1521 9.22427,12.1228 9.15992,12.0989 L 8.92858,12.0445 8.76144,12.0364 8.69619,12.0211 C 8.53401,12.0302 8.37528,12.0716 8.22934,12.1429 L 8.15607,12.1883 C 8.11041,12.2127 8.06636,12.24 8.02418,12.2699 L 7.94393,12.345 c -0.03108,0.0269 -0.06078,0.0555 -0.08897,0.0855 -0.04049,0.0469 -0.07735,0.0968 -0.11025,0.1493 l -0.01116,0.0475 c 0,0 -0.00976,0.0415 -0.01395,0.0593 -0.05381,0.0904 -0.09002,0.1902 -0.10675,0.2941 -0.00837,0.0356 -0.01534,0.0653 -0.02372,0.1009 -0.0147,0.0486 -0.02635,0.0982 -0.03488,0.1483 0,0 -0.01255,0.0534 -0.01813,0.0771 0.0044,0.0812 0.01691,0.1617 0.03735,0.2404 L 9.6185,21.434 9.61013,21.4696 c 0.02434,0.0842 0.05769,0.1655 0.09946,0.2425 l -0.00837,0.0356 c 0.05067,0.0813 0.11077,0.1564 0.17902,0.2237 l 0.05688,0.0509 c 0.05658,0.049 0.11758,0.0927 0.18218,0.1305 l 0.0771,0.0181 c 0.0858,0.0443 0.1766,0.0783 0.2704,0.1012 0.077,0.0265 0.1565,0.0452 0.2373,0.0558 l 0.0712,0.0167 c 0.0675,-0.0037 0.1346,-0.013 0.2006,-0.0279 l 0.0356,0.0084 7.8615,-2.0447 0.1235,-0.0461 0.0618,-0.023 c 0.1029,-0.0455 0.1991,-0.105 0.2857,-0.1769 l 0.0482,-0.0451 c 0.0884,-0.0791 0.1648,-0.1708 0.2268,-0.2721 0,0 0.0097,-0.0416 0.0139,-0.0594 0.0528,-0.0886 0.0885,-0.1864 0.1054,-0.2882 0.0083,-0.0356 0.0153,-0.0652 0.0237,-0.1008 0.0147,-0.0487 0.0263,-0.0982 0.0349,-0.1483 0,0 0.0125,-0.0534 0.0181,-0.0771 -0.0091,-0.1622 -0.0505,-0.3209 -0.1218,-0.4669 l -0.0499,-0.0806 c -0.0232,-0.043 -0.049,-0.0846 -0.0771,-0.1245 l -0.0855,-0.089 0.0146,-0.1155 c -0.0595,-0.0526 -0.124,-0.0992 -0.1926,-0.1392 L 15.018,15.5112 c 3.8063,-4.4179 9.9608,-5.99877 15.4251,-3.9623 5.4643,2.0366 9.0829,7.2599 9.0694,13.0913 -0.0135,5.8315 -3.6563,11.0379 -9.13,13.049 -5.4737,2.0112 -11.6208,0.4017 -15.4066,-4.0338 -0.442,-0.4883 -1.1921,-0.5371 -1.6937,-0.1101 -0.5015,0.427 -0.573,1.1753 -0.1614,1.6895 5.262,6.1125 14.1895,7.487 21.0464,3.2402 6.8568,-4.2468 9.6036,-12.8517 6.4755,-20.2858 z" fill="white"/></svg>
+            </button>
+            <button id="removeButton" type="button" class="chuck-button bg-[#FF6868]" aria-label="Remove" disabled>
+              <svg viewBox="5 18 40 14" fill="none" class="w-5 h-5"><rect x="9.89172" y="22.67" width="30.5172" height="5.23153" fill="white"/></svg>
+            </button>
+            <button id="recordButton" type="button" class="chuck-button bg-white" aria-label="Record" disabled>
+              <svg viewBox="13 13 24 24" fill="none" class="w-5 h-5"><circle cx="25" cy="25" r="10" fill="#FF6868"/></svg>
+            </button>
           </div>
-
-          <!-- right side -->
-          <div id="chuckBarRight" class="flex justify-right items-center">
-            <div id="chuckNowStatus" class="pr-2">
-              <span class="text-orange"><b>now:</b></span>
-              <span id="chuckNowTime" class="font-mono text-dark-4 dark:text-light text-sm">00:00:00.00000</span>
-            </div>
-          </div>
-        </div>
       </div>
 
 
@@ -284,7 +261,7 @@
         <!-- Left -->
         <div id="app-left">
           <div id="fileExplorerPanel" class="h-full flex flex-col justify-start">
-            <div id="fileExplorerHeader" class="header h-8 justify-start flex-none border-b border-dark-d dark:border-dark-a drop-shadow-sm font-bold overflow-hidden whitespace-nowrap">
+            <div id="fileExplorerHeader" class="header h-10 justify-start flex-none border-b border-dark-d dark:border-dark-a drop-shadow-sm font-bold overflow-hidden whitespace-nowrap">
               <div class="px-2">File Explorer</div>
             </div>
             <div id="fileExplorerContainer">
@@ -301,6 +278,7 @@
                 </div>
               </div>
             </div>
+            <div id="fileExplorerFooter" class="header h-[30px] flex-none border-b-0 border-t-2"></div>
           </div>
         </div>
 
@@ -311,15 +289,15 @@
           <!-- Editor Panel -->
           <div id="editorPanel" class="h-full flex flex-col justify-start">
             <!-- Monaco -->
-            <div id="editorPanelHeader" class="header h-8 justify-start flex-none">
+            <div id="editorPanelHeader" class="header h-10 justify-start flex-none">
               <button id="fileToggle" type="button" class="header-item icon px-1 mr-1" aria-label="Toggle File Explorer">
                 <svg class="w-6 h-5" aria-hidden="true" viewBox="0 0 30 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path stroke="currentColor" d="M3 0C1.35862 0 0 1.35862 0 3V21C0 22.6414 1.35862 24 3 24H27C28.6414 24 30 22.6414 30 21V6C30 4.35862 28.6414 3 27 3H15L12 0H3ZM3 3H10.7578L13.7578 6H27V21H3V3Z" fill="currentColor"/>
                 </svg>
               </button>
-              <div id="filename" class="header-item">untitled.ck</div>
+              <div id="filename" class="px-2 text-base font-bold truncate min-w-0">untitled.ck</div>
             </div>
-            <div id="monacoEditor" style="height: calc(100% - 2rem - 1.75rem - 1px); width: 100%;"></div>
+            <div id="monacoEditor"></div>
             <div id=vimStatus class="border-none bg-gray-200 dark:bg-dark-4 w-full h-7 px-0.5 text-sm items-center flex-none hidden"></div>
           </div>
           <div id="splitH1" class="resizer hSplit"></div>
@@ -370,37 +348,45 @@
         <div id="splitV2" class="resizer vSplit"></div>
 
         <!-- Right -->
-        <div id="app-right">
-          <!-- VM Monitor -->
-          <div id="vmMonitor" class="relative">
-            <table id="shredTable" class="w-full table-auto absolute text-left overflow-auto">
-              <thead class="h-8 align-middle font-medium border-b border-dark-d dark:border-dark-a drop-shadow-sm">
-                <tr>
-                  <th scope="col">Shred</th>
-                  <th scope="col">Code</th>
-                  <th scope="col">Time</th>
-                  <th scope="col" style="width: 10%;">Remove</th>
-                </tr>
-              </thead>
-              <tbody>
-              </tbody>
-            </table>
-          </div>
-          <div id="splitH2" class="resizer hSplit"></div>
+        <div id="app-right" class="flex flex-col">
           <!-- Output Panel -->
-          <div id="outputPanel" class="flex flex-col dark:bg-dark">
-            <div id="outputPanelHeader" class="header h-7 justify-start flex-none drop-shadow-sm">
-              <button id="consoleTab"    type="button" class="header-item text-orange underline transition">CONSOLE</button>
+          <div id="outputPanel" class="flex flex-col flex-1 min-h-0">
+            <div id="outputPanelHeader" class="header h-10 justify-start flex-none drop-shadow-sm">
+              <button id="consoleTab"    type="button" class="header-item text-dark-5">CONSOLE</button>
+              <button id="vmMonitorTab"  type="button" class="header-item text-dark-5">VM MONITOR</button>
               <button id="visualizerTab" type="button" class="header-item text-dark-5">VISUALIZER</button>
             </div>
-            <div id="consoleContainer" style="height: calc(100% - 1.75rem)" class="border-b border-sky-blue dark:border-dark-4">
-              <div id="console" class="bg-white dark:bg-dark-2 h-full"></div>
+            <div id="consoleContainer" class="hidden relative">
+              <div id="console" class="absolute inset-0"></div>
             </div>
-            <div id="visualizerContainer" class="flex-1 bg-white dark:bg-dark-2 hidden">
-              <div id="visualizer-help" class="w-full h-full flex items-center justify-center text-[#666] dark:text-[#bbb] transition">
+            <div id="vmMonitorContainer" class="hidden relative">
+              <div class="absolute inset-0 overflow-auto">
+                <table id="shredTable" class="w-full table-auto text-left">
+                  <thead class="h-12 align-middle font-medium sticky top-0 z-10">
+                    <tr>
+                      <th scope="col" class="border-b">Shred</th>
+                      <th scope="col" class="border-b">Code</th>
+                      <th scope="col" class="border-b">Time</th>
+                      <th scope="col" class="border-b" style="width: 10%;">Remove</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <div id="visualizerContainer" class="hidden relative">
+              <div id="visualizer-help" class="absolute inset-0 flex items-center justify-center text-[#666] dark:text-[#bbb] transition">
                 <b>Start WebChucK for visualizer</b>
               </div>
-              <canvas id="visualizer" class="w-full h-full"></canvas>
+              <canvas id="visualizer" class="absolute inset-0 w-full h-full"></canvas>
+            </div>
+          </div>
+          <!-- VM Monitor Status Bar -->
+          <div id="vmMonitorStatusBar" class="flex-none flex items-center justify-end px-2 h-[30px] text-s border-t-2">
+            <div id="chuckNowStatus" class="opacity-70 pointer-events-none whitespace-nowrap h-6 flex items-center gap-1" style="display: none;">
+              <span class="text-orange font-mono"><b>now:</b></span>
+              <span id="chuckNowTime" class="font-mono text-dark-4 dark:text-light">00:00:00.00000</span>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@
 
 
       <!-- CHUCK BAR -->
-      <div id="chuckBar" class="bg-orange-peach dark:bg-dark-4 flex items-center justify-end px-2 py-1 gap-2">
+      <div id="chuckBar" class="bg-orange-peach dark:bg-dark-4 flex items-center justify-start px-2 py-1 gap-2">
           <div class="flex items-center gap-2 flex-shrink-0">
             <button id="webchuckButton" type="button" class="chuck-button h-10 font-semibold bg-orange text-white text-base px-3 enabled:hover:bg-orange-400 transition-all overflow-hidden truncate disabled:opacity-50" disabled>Loading...</button>
             <button id="micButton" type="button" class="chuck-button bg-[#CF68FF] disabled:opacity-50" title="Enable Microphone" aria-label="Enable Microphone" disabled>
@@ -278,7 +278,6 @@
                 </div>
               </div>
             </div>
-            <div id="fileExplorerFooter" class="header h-[30px] flex-none border-b-0 border-t-2"></div>
           </div>
         </div>
 
@@ -295,7 +294,7 @@
                   <path stroke="currentColor" d="M3 0C1.35862 0 0 1.35862 0 3V21C0 22.6414 1.35862 24 3 24H27C28.6414 24 30 22.6414 30 21V6C30 4.35862 28.6414 3 27 3H15L12 0H3ZM3 3H10.7578L13.7578 6H27V21H3V3Z" fill="currentColor"/>
                 </svg>
               </button>
-              <div id="filename" class="px-2 text-base font-bold truncate min-w-0">untitled.ck</div>
+              <div id="filename" class="header-item">untitled.ck</div>
             </div>
             <div id="monacoEditor"></div>
             <div id=vimStatus class="border-none bg-gray-200 dark:bg-dark-4 w-full h-7 px-0.5 text-sm items-center flex-none hidden"></div>
@@ -352,15 +351,12 @@
           <!-- Output Panel -->
           <div id="outputPanel" class="flex flex-col flex-1 min-h-0">
             <div id="outputPanelHeader" class="header h-10 justify-start flex-none drop-shadow-sm">
-              <button id="consoleTab"    type="button" class="header-item text-dark-5">CONSOLE</button>
               <button id="vmMonitorTab"  type="button" class="header-item text-dark-5">VM MONITOR</button>
+              <button id="consoleTab"    type="button" class="header-item text-dark-5">CONSOLE</button>
               <button id="visualizerTab" type="button" class="header-item text-dark-5">VISUALIZER</button>
             </div>
-            <div id="consoleContainer" class="hidden relative">
-              <div id="console" class="absolute inset-0"></div>
-            </div>
-            <div id="vmMonitorContainer" class="hidden relative">
-              <div class="absolute inset-0 overflow-auto">
+            <div id="vmMonitorContainer" role="tabpanel" class="hidden flex flex-col">
+              <div class="flex-1 min-h-0 overflow-auto">
                 <table id="shredTable" class="w-full table-auto text-left">
                   <thead class="h-12 align-middle font-medium sticky top-0 z-10">
                     <tr>
@@ -374,19 +370,19 @@
                   </tbody>
                 </table>
               </div>
+              <div id="chuckNowStatus" class="shrink-0 whitespace-nowrap px-2 flex items-center justify-end gap-1 text-sm bg-sky-blue-300 dark:bg-dark border-t border-sky-blue-700 dark:border-dark-5" style="display: none; height: 30px;">
+                <span class="text-orange font-mono"><b>now:</b></span>
+                <span id="chuckNowTime" class="font-mono text-dark-4 dark:text-light">00:00:00.00000</span>
+              </div>
             </div>
-            <div id="visualizerContainer" class="hidden relative">
+            <div id="consoleContainer" role="tabpanel" class="hidden relative">
+              <div id="console" class="absolute inset-0"></div>
+            </div>
+            <div id="visualizerContainer" role="tabpanel" class="hidden relative bg-white dark:bg-dark-2">
               <div id="visualizer-help" class="absolute inset-0 flex items-center justify-center text-[#666] dark:text-[#bbb] transition">
                 <b>Start WebChucK for visualizer</b>
               </div>
               <canvas id="visualizer" class="absolute inset-0 w-full h-full"></canvas>
-            </div>
-          </div>
-          <!-- VM Monitor Status Bar -->
-          <div id="vmMonitorStatusBar" class="flex-none flex items-center justify-end px-2 h-[30px] text-s border-t-2">
-            <div id="chuckNowStatus" class="opacity-70 pointer-events-none whitespace-nowrap h-6 flex items-center gap-1" style="display: none;">
-              <span class="text-orange font-mono"><b>now:</b></span>
-              <span id="chuckNowTime" class="font-mono text-dark-4 dark:text-light">00:00:00.00000</span>
             </div>
           </div>
         </div>

--- a/src/components/editor/monaco/editor.ts
+++ b/src/components/editor/monaco/editor.ts
@@ -20,7 +20,6 @@ import ProjectSystem from "../../fileExplorer/projectSystem";
 import GUI from "@/components/inputPanel/gui/gui";
 
 // Constants
-const HEADER_HEIGHT: string = "2rem";
 const VIM_STATUS_HEIGHT: string = "1.75rem";
 
 // Define editor themes
@@ -232,10 +231,10 @@ export default class Editor {
      * Turn on Vim mode and configure the editor height
      */
     vimModeOn() {
-        // Change Monaco Editor Height to compensate for Vim status bar
+        // Adjust editor bottom to make room for Vim status bar
         Editor.editorContainer.setAttribute(
             "style",
-            `height: calc(100% - ${HEADER_HEIGHT} - ${VIM_STATUS_HEIGHT} - 1px)`
+            `bottom: ${VIM_STATUS_HEIGHT}`
         );
         Editor.resizeEditor();
         Editor.vimModule = initVimMode(Editor.editor, Editor.vimStatus);
@@ -250,10 +249,10 @@ export default class Editor {
      * Turn off Vim mode
      */
     vimModeOff() {
-        // Change Monaco Editor Height to compensate for Vim status bar
+        // Reset editor to stretch to bottom
         Editor.editorContainer.setAttribute(
             "style",
-            `height: calc(100% - ${HEADER_HEIGHT} - 1px)`
+            "bottom: 0"
         );
         Editor.resizeEditor();
         Editor.vimModule?.dispose();

--- a/src/components/outputPanel/outputPanelHeader.ts
+++ b/src/components/outputPanel/outputPanelHeader.ts
@@ -33,7 +33,8 @@ export default class OutputPanelHeader {
         );
         new OutputHeaderToggle(
             vmMonitorButton,
-            OutputPanelHeader.vmMonitorContainer
+            OutputPanelHeader.vmMonitorContainer,
+            true
         );
         new OutputHeaderToggle(
             visualizerButton,

--- a/src/components/outputPanel/outputPanelHeader.ts
+++ b/src/components/outputPanel/outputPanelHeader.ts
@@ -1,12 +1,10 @@
 import Console from "@/components/outputPanel/console";
 import OutputHeaderToggle from "@components/toggle/outputHeaderToggle";
 import { visual } from "@/host";
-import { openOutputPanel } from "@/utils/appLayout";
-
-const OUTPUT_HEADER_HEIGHT: number = 1.75; // rem
 
 export default class OutputPanelHeader {
     public static consoleContainer: HTMLDivElement;
+    public static vmMonitorContainer: HTMLDivElement;
     public static visualizerContainer: HTMLDivElement;
 
     constructor() {
@@ -16,6 +14,11 @@ export default class OutputPanelHeader {
             document.querySelector<HTMLButtonElement>("#consoleTab")!;
         OutputPanelHeader.consoleContainer =
             document.querySelector<HTMLDivElement>("#consoleContainer")!;
+        // VM Monitor
+        const vmMonitorButton =
+            document.querySelector<HTMLButtonElement>("#vmMonitorTab")!;
+        OutputPanelHeader.vmMonitorContainer =
+            document.querySelector<HTMLDivElement>("#vmMonitorContainer")!;
         // Visualizer
         const visualizerButton =
             document.querySelector<HTMLButtonElement>("#visualizerTab")!;
@@ -29,30 +32,41 @@ export default class OutputPanelHeader {
             true
         );
         new OutputHeaderToggle(
+            vmMonitorButton,
+            OutputPanelHeader.vmMonitorContainer
+        );
+        new OutputHeaderToggle(
             visualizerButton,
             OutputPanelHeader.visualizerContainer
         );
+
+        // Recalculate split heights on window resize
+        window.addEventListener("resize", () => {
+            OutputPanelHeader.updateOutputPanel(
+                OutputHeaderToggle.numActive
+            );
+        });
     }
 
     /**
-     * Update the CSS for the Output Panel based on the number of tabs that are toggled
+     * Update the Output Panel after a tab toggle or resize.
+     * Content uses absolute-inset-0 containment so CSS flex: 1 1 0%
+     * handles equal sizing; we only need to re-fit xterm and the visualizer.
      * @param tabsActive number of tabs active
-     * @returns
      */
     static updateOutputPanel(tabsActive: number) {
-        // Open output panel if more than 0 tab is open
+        document.getElementById("app")?.classList.toggle(
+            "output-collapsed",
+            tabsActive === 0
+        );
+
         if (tabsActive === 0) {
-            openOutputPanel(false);
             return;
         }
 
-        openOutputPanel(true);
-        // Split the container heights evenly
-        const splitHeight: string = `calc((100% - ${OUTPUT_HEADER_HEIGHT}rem)/${tabsActive})`;
-        OutputPanelHeader.consoleContainer.style.height = splitHeight;
-        OutputPanelHeader.visualizerContainer.style.height = splitHeight;
-
-        Console.resizeConsole();
-        visual?.resize();
+        requestAnimationFrame(() => {
+            Console.resizeConsole();
+            visual?.resize();
+        });
     }
 }

--- a/src/components/vmMonitor.ts
+++ b/src/components/vmMonitor.ts
@@ -23,7 +23,7 @@ export default class VmMonitor {
 
     constructor() {
         VmMonitor.vmContainer =
-            document.querySelector<HTMLDivElement>("#vmMonitor")!;
+            document.querySelector<HTMLDivElement>("#vmMonitorContainer")!;
         const shredTable =
             document.querySelector<HTMLDivElement>("#shredTable")!;
         VmMonitor.shredTableBody = shredTable.getElementsByTagName("tbody")[0]!;
@@ -99,12 +99,12 @@ export default class VmMonitor {
         })(time, theShred);
 
         // Remove button
-        const removeButton = document.createElement("input");
-        removeButton.setAttribute("type", "image");
-        removeButton.setAttribute("src", "img/remove.svg");
+        const removeButton = document.createElement("button");
+        removeButton.type = "button";
         removeButton.classList.add("removeButton");
-        removeButton.setAttribute("alt", "remove button");
         removeButton.setAttribute("aria-label", "Remove Shred");
+        removeButton.innerHTML =
+            "<svg viewBox=\"5 18 40 14\" fill=\"none\" class=\"w-4 h-4\"><rect x=\"9.89\" y=\"22.67\" width=\"30.52\" height=\"5.23\" fill=\"white\"/></svg>";
         remove.appendChild(removeButton);
 
         remove.addEventListener("click", () => {
@@ -184,7 +184,7 @@ export class ChuckNow {
         if (isDisplay) {
             // On
             ChuckNow.chuckNowToggle.innerText = "ChucK Time: On";
-            ChuckNow.chuckNowStatus.style.display = "block";
+            ChuckNow.chuckNowStatus.style.display = "flex";
             ChuckNow.isDisplay = localStorage["chuckNow"] = true;
         } else {
             ChuckNow.chuckNowToggle.innerText = "ChucK Time: Off";

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -11,19 +11,17 @@
     -webkit-touch-callout: none;
 }
 
-#chuck-bar {
-    grid-area: chuck-bar;
-    user-select: none;
-    -webkit-touch-callout: none;
+#chuckBar {
+    grid-area: chuckBar;
 }
 
 #webchuck-ide {
     display: grid;
-    grid-template-rows: 3rem 3.5rem auto;
+    grid-template-rows: 3rem auto 1fr;
     grid-template-columns: 100%;
     grid-template-areas:
         "nav"
-        "chuck-bar"
+        "chuckBar"
         "app";
     overflow: hidden;
 }
@@ -35,44 +33,53 @@
     grid-template-areas: "app-left splitV1 app-middle splitV2 app-right";
     /* app column widths */
     grid-template-columns: 2fr 2px 6fr 2px 4fr;
-    grid-template-rows: 100%;
+    grid-template-rows: 1fr;
 }
 
 /* Mobile Layout */
 @media (max-width: 640px) {
     #webchuck-ide {
-        height: 160vh;
+        height: 100vh;
+        height: 100dvh;
     }
 
     #app {
         @apply px-2 pb-2;
         grid-template-areas:
             "app-middle"
-            "splitH2"
+            "."
             "app-right";
         grid-template-rows: 5fr 2px 5fr;
         grid-template-columns: 100%;
     }
 
-    #chuck-bar {
-        width: 100%;
-    }
-
-    #chuckBarLeft {
-        /* 
-            @tzfeng
-            weird hack to make mobile look good
-            cut off the record button on mobile
-        */
-        width: calc(100% + 4rem);
-    }
-
-    #chuckBarRight {
+    #app-left, #splitV1, #splitV2 {
         display: none;
+    }
+
+    #chuckBar {
+        overflow: hidden;
+    }
+
+    #chuckBar > div:last-child {
+        flex: 1 1 0 !important;
+        min-width: 0;
+        justify-content: space-evenly;
+    }
+
+    #chuckBar .chuck-button {
+        flex: 0 1 auto;
+        min-width: 0;
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
     }
 
     #fileToggle {
         pointer-events: none;
+    }
+
+    #app.output-collapsed {
+        grid-template-rows: 1fr 2px auto;
     }
 }
 
@@ -89,9 +96,6 @@
     grid-area: splitH1;
 }
 
-#splitH2 {
-    grid-area: splitH2;
-}
 
 #app-left {
     grid-area: app-left;
@@ -115,13 +119,8 @@
 #app-right {
     grid-area: app-right;
     min-width: 1rem;
-    display: grid;
-    grid-template-areas:
-        "vm-monitor"
-        "splitH2"
-        "outputPanel";
-    grid-template-columns: 100%;
-    grid-template-rows: calc(50% - 2px) 2px 50%;
+    display: flex;
+    flex-direction: column;
     height: 100%;
     overflow: hidden;
 }
@@ -183,10 +182,15 @@
 }
 
 /* CHUCK BAR */
-#chuck-bar .chuck-button {
-    @apply px-1 mr-2 disabled:opacity-50 focus:outline-none enabled:hover:filter enabled:hover:invert-20 transition duration-300 focus-visible:ring-2 focus-visible:ring-blue-600 dark:focus-visible:ring-blue-200 rounded-lg focus-visible:ring-offset-2 dark:focus-visible:ring-offset-dark;
-    min-width: 2.75rem;
-    /* same height as chuck button */
+#chuckBar .chuck-button {
+    @apply rounded-md flex items-center justify-center disabled:opacity-50 focus:outline-none enabled:hover:brightness-110 transition duration-300 focus-visible:ring-2 focus-visible:ring-blue-600 dark:focus-visible:ring-blue-200 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-dark;
+    margin: 0.25rem 0;
+    padding: 0.375rem 0.75rem;
+}
+
+#chuckBar .chuck-button svg {
+    width: 1.75rem;
+    height: 1.75rem;
 }
 
 /* FILE EXPLORER */
@@ -252,6 +256,7 @@
 #editorPanel {
     grid-area: editorPanel;
     overflow: hidden;
+    position: relative;
 }
 
 #inputPanel {
@@ -259,21 +264,35 @@
     user-select: none;
 }
 
-#vmMonitor {
-    grid-area: vm-monitor;
-    overflow: auto;
+#vmMonitorContainer,
+#consoleContainer,
+#visualizerContainer {
+    flex: 1 1 0%;
+    min-height: 0;
+    overflow: hidden;
+}
+
+#vmMonitorContainer {
     user-select: none;
 }
 
+#console > .xterm {
+    height: 100%;
+    box-sizing: border-box;
+}
+
 #outputPanel {
-    grid-area: outputPanel;
+    overflow: hidden;
     user-select: none;
 }
 
 /* EDITOR */
 #monacoEditor {
-    /* position: absolute !important; */
-    height: 100%;
+    position: absolute;
+    top: 2.5rem;
+    left: 0;
+    right: 0;
+    bottom: 0;
 }
 
 .rendered-markdown>p>strong>span {
@@ -332,7 +351,7 @@ td:nth-child(4) {
 }
 
 .removeButton {
-    @apply h-7 px-2 m-auto block focus:outline-none hover:filter hover:invert-20 transition duration-300;
+    @apply h-7 px-2 m-auto flex items-center justify-center bg-[#FF6868] rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 dark:focus-visible:ring-blue-200 hover:brightness-110 transition duration-300;
 }
 
 /* INPUT PANEL */
@@ -379,11 +398,11 @@ td:nth-child(4) {
 
 /* MISC. COMPONENTS */
 .button.primary {
-    @apply bg-orange hover:bg-orange-light px-3 py-1.5 text-white transition rounded-lg;
+    @apply bg-orange hover:bg-orange-light px-3 py-1.5 text-white transition rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-orange focus-visible:ring-offset-2;
 }
 
 .button.secondary {
-    @apply text-orange hover:text-orange-light border border-orange hover:border-orange-light px-3 py-1.5 rounded-lg transition;
+    @apply text-orange hover:text-orange-light border border-orange hover:border-orange-light px-3 py-1.5 rounded-md transition focus:outline-none focus-visible:ring-2 focus-visible:ring-orange focus-visible:ring-offset-2;
 }
 
 dialog {
@@ -494,10 +513,10 @@ dialog::backdrop {
 }
 
 .header {
-    @apply w-full flex items-center px-1 border-b border-sky-blue-700 dark:border-dark-5;
+    @apply w-full flex items-center px-1 border-b;
 }
 
 .header-item {
-    @apply text-sm px-2 transition duration-300;
+    @apply text-sm px-2 transition duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-600 dark:focus-visible:ring-blue-200 rounded;
     user-select: none;
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -286,6 +286,11 @@
     user-select: none;
 }
 
+#outputPanel>[role=tabpanel]:not(.hidden)+[role=tabpanel]:not(.hidden),
+#outputPanel>[role=tabpanel]:not(.hidden)+.hidden+[role=tabpanel]:not(.hidden) {
+    border-top: 1px solid rgb(68 68 68 / var(--tw-border-opacity, 1));
+}
+
 /* EDITOR */
 #monacoEditor {
     position: absolute;
@@ -320,6 +325,10 @@ span>.monaco-tokenized-source {
 }
 
 #vimStatus {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
     min-width: 64px;
     overflow: hidden;
 }

--- a/src/utils/appLayout.ts
+++ b/src/utils/appLayout.ts
@@ -28,8 +28,6 @@ const MIDDLE_WIDTH: number = 50;
 const RIGHT_WIDTH: number = 33.33;
 const EDITOR_PANEL_HEIGHT: number = window.innerWidth <= 800 ? 60 : 70; // mobile
 const INPUT_PANEL_HEIGHT: number = window.innerWidth <= 800 ? 40 : 30;
-const VM_MONITOR_HEIGHT: number = 50;
-const OUTPUT_PANEL_HEIGHT: number = 50;
 
 // if mobile, set INPUT height to 50
 // if mobile, set OUTPUT height to 50
@@ -41,10 +39,8 @@ const OUTPUT_PANEL_HEIGHT: number = 50;
 const appContainer = document.getElementById("app")!;
 const left_panel = document.getElementById("app-left")!;
 const middle_panel = document.getElementById("app-middle")!;
-const right_panel = document.getElementById("app-right")!;
 // const editor_panel = document.getElementById("editorPanel")!;
 // const input_panel = document.getElementById("inputPanel")!;
-// const vm_monitor_panel = document.getElementById("vmMonitor")!;
 // const output_panel = document.getElementById("outputPanel")!;
 
 // Initialize App Dimensions
@@ -58,8 +54,6 @@ let left_open = true;
 // let right_open = true;
 //let editor_open = true;
 let input_panel_open = false;
-//let vm_monitor = true;
-let output_panel_open = true;
 
 // App Layout Splitters
 const splitters: Resizer[] = [];
@@ -73,9 +67,7 @@ export const AppLayoutConstants = {
     MIDDLE_WIDTH,
     RIGHT_WIDTH,
     EDITOR_PANEL_HEIGHT,
-    VM_MONITOR_HEIGHT,
     INPUT_PANEL_HEIGHT,
-    OUTPUT_PANEL_HEIGHT,
 };
 
 // Initialize the app splitters
@@ -132,8 +124,6 @@ export function setContainerRowHeights(
     }
     if (container.id == "app-middle") {
         input_panel_open = isBottomOpen;
-    } else {
-        output_panel_open = isBottomOpen;
     }
     container.style.gridTemplateRows = heights.join(" ");
 }
@@ -189,28 +179,6 @@ export function openInputPanel(open: boolean) {
         input_panel_open = false;
     }
     Editor.resizeEditor();
-}
-
-/**
- * Open the Output Panel to the default height
- * @param open
- */
-export function openOutputPanel(open: boolean) {
-    if (open == output_panel_open) return;
-
-    if (open) {
-        // open output panel
-        setContainerRowHeights(
-            right_panel,
-            VM_MONITOR_HEIGHT,
-            OUTPUT_PANEL_HEIGHT
-        );
-        output_panel_open = true;
-    } else {
-        // close output panel
-        setContainerRowHeights(right_panel, -1, `${MIN_SIZE_V}px`);
-        output_panel_open = false;
-    }
 }
 
 /**


### PR DESCRIPTION
* chuck bar: moved buttons to the right. action buttons now have same border radius as the other buttons
* output panel: refactored HTML structure (more robust now, in preparation for adding the canvas)
* mobile: now (more) responsive!
* vm monitor: moved to output panel
* share button: moved to the right of WebChucK IDE 2
* headers: increased height to h-10
* ChucK time: moved from ChucK bar to status bar at the bottom of the output panel
* file explorer: added bottom bar to match the other panels (in preparation for chicken)
* standardized button border radius (modal buttons, action buttons, share button, etc...)
