### PR TITLE
qol-1-css&bugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,13 +55,13 @@
     text-base text-dark dark:text-light">
 
       <!-- NAVBAR -->
-      <div id="navbarWrapper" class="w-full relative">
+      <header id="navbarWrapper" class="w-full relative">
         <nav id="navbar" class="flex h-full items-center justify-between md:px-2 px-4 overflow-x-auto">
 
           <!-- Left -->
           <div class="flex justify-left items-center">
             <!-- ChucK Logo -->
-            <a href="https://chuck.stanford.edu" class="w-10 md:w-8" target="_blank">
+            <a href="https://chuck.stanford.edu" class="w-10 md:w-8" target="_blank" rel="noopener noreferrer">
               <img src="img/ChonK.svg" class="h-10 md:h-8" alt="ChucK Logo" />
             </a>
 
@@ -77,47 +77,47 @@
                   </svg>
                 </button>
                 <div id="fileDropdown" class="hidden dropdown w-40">
-                  <ul class="py-2 text-base text-gray-700 dark:text-light" aria-labelledby="dropdownDefaultButton">
-                    <li>
-                      <button id="newFile" type="button" class="dropdownItem">
+                  <ul class="py-2 text-base text-gray-700 dark:text-light" aria-labelledby="fileButton" role="menu">
+                    <li role="separator">
+                      <button id="newFile" type="button" class="dropdownItem" role="menuitem">
                         New
                       </button>
                     </li>
-                    <li>
-                      <input id="fileUploader" type="file" multiple hidden />
-                      <button id="uploadFiles" type="button" class="dropdownItem disabled:opacity-50" disabled>
+                    <li role="separator">
+                      <input id="fileUploader" type="file" multiple hidden aria-label="Upload files" />
+                      <button id="uploadFiles" type="button" class="dropdownItem disabled:opacity-50" role="menuitem" disabled>
                         Upload Files
                       </button>
                     </li>
-                    <li>
-                      <button id="newProject" type="button" class="dropdownItem">
+                    <li role="separator">
+                      <button id="newProject" type="button" class="dropdownItem" role="menuitem">
                         New Project
                       </button>
                     </li>
-                    <li id="exportToContainer" class="relative">
-                      <button id="exportToButton" type="button" class="dropdownItem nestedDropdownButton">
+                    <li id="exportToContainer" class="relative" role="separator">
+                      <button id="exportToButton" type="button" class="dropdownItem nestedDropdownButton" role="menuitem">
                         Export to
                         <svg class="w-2.5 h-2.5 ml-3 rtl:rotate-180" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">
                           <path stroke="currentColor" stroke-linecap="" stroke-linejoin="round" stroke-width="1.5" d="m1 9 4-4-4-4"/>
                         </svg>
                       </button>
                       <div id="exportToDropdown" class="nestedDropdown w-36 hidden">
-                        <ul class="py-2 text-base text-gray-700 dark:text-gray-200">
-                          <li>
-                            <button id="exportChuck" type="button" class="dropdownItem">
+                        <ul class="py-2 text-base text-gray-700 dark:text-gray-200" role="menu" aria-labelledby="exportToButton">
+                          <li role="separator">
+                            <button id="exportChuck" type="button" class="dropdownItem" role="menuitem">
                               ChucK
                             </button>
                           </li>
-                          <li>
-                            <button id="exportWebchuck" type="button" class="dropdownItem">
+                          <li role="separator">
+                            <button id="exportWebchuck" type="button" class="dropdownItem" role="menuitem">
                               WebChucK
                             </button>
                           </li>
                         </ul>
                       </div>
                     </li>
-                    <li>
-                      <button id="openSettings" type="button" class="dropdownItem">
+                    <li role="separator">
+                      <button id="openSettings" type="button" class="dropdownItem" role="menuitem">
                         Settings
                       </button>
                     </li>
@@ -133,9 +133,9 @@
                   </svg>
                 </button>
                 <div id="editDropdown" class="hidden dropdown w-40">
-                  <ul class="py-2 text-base text-gray-700 dark:text-gray-200" aria-labelledby="dropdownDefaultButton">
-                    <li>
-                      <button id="vimToggle" type="button" class="dropdownItem">
+                  <ul class="py-2 text-base text-gray-700 dark:text-gray-200" aria-labelledby="editButton" role="menu">
+                    <li role="separator">
+                      <button id="vimToggle" type="button" class="dropdownItem" role="menuitem">
                         Vim Mode: Off
                       </button>
                     </li>
@@ -151,20 +151,20 @@
                   </svg>
                 </button>
                 <div id="viewDropdown" class="hidden dropdown w-40">
-                  <ul class="py-2 text-base text-gray-700 dark:text-gray-200" aria-labelledby="dropdownDefaultButton">
-                    <li>
-                      <button id="chuckNowToggle" type="button" class="dropdownItem">
+                  <ul class="py-2 text-base text-gray-700 dark:text-gray-200" aria-labelledby="viewButton" role="menu">
+                    <li role="separator">
+                      <button id="chuckNowToggle" type="button" class="dropdownItem" role="menuitem">
                         ChucK Time: Off
                       </button>
                     </li>
-                    <li class="divider dark:border-t-gray-400" data-content="THEME"></li>
-                    <li>
-                      <button id="darkModeToggle" type="button" class="dropdownItem disabled:opacity-50">
+                    <li class="divider dark:border-t-gray-400" data-content="THEME" role="separator"></li>
+                    <li role="separator">
+                      <button id="darkModeToggle" type="button" class="dropdownItem disabled:opacity-50" role="menuitem">
                         Mode: Light
                       </button>
                     </li>
-                    <li>
-                      <button id="colorPreferenceToggle" type="button" class="dropdownItem">
+                    <li role="separator">
+                      <button id="colorPreferenceToggle" type="button" class="dropdownItem" role="menuitem">
                         System: On
                       </button>
                     </li>
@@ -180,7 +180,7 @@
                   </svg>
                 </button>
                 <div id="examplesDropdown" class="hidden dropdown w-48">
-                  <ul id="examplesDropdownContainer" class="py-2 text-base text-gray-700 dark:text-gray-200" aria-labelledby="dropdownDefaultButton">
+                  <ul id="examplesDropdownContainer" class="py-2 text-base text-gray-700 dark:text-gray-200" aria-labelledby="examplesButton" role="menu">
                   </ul>
                 </div>
               </div>
@@ -193,28 +193,28 @@
                   </svg>
                 </button>
                 <div id="helpDropdown" class="hidden dropdown w-52">
-                  <ul class="py-2 text-base text-gray-700 dark:text-gray-200" aria-labelledby="dropdownDefaultButton">
-                    <li>
-                      <a href="https://chuck.stanford.edu/doc/reference" target="_blank" class="dropdownItem">ChucK API Reference</a>
+                  <ul class="py-2 text-base text-gray-700 dark:text-gray-200" aria-labelledby="helpButton" role="menu">
+                    <li role="separator">
+                      <a href="https://chuck.stanford.edu/doc/reference" target="_blank" rel="noopener noreferrer" class="dropdownItem" role="menuitem">ChucK API Reference</a>
                     </li>
-                    <li>
-                      <a href="https://chuck.stanford.edu/webchuck/" target="_blank" class="dropdownItem">Learn WebChucK</a>
+                    <li role="separator">
+                      <a href="https://chuck.stanford.edu/webchuck/" target="_blank" rel="noopener noreferrer" class="dropdownItem" role="menuitem">Learn WebChucK</a>
                     </li>
-                    <li>
-                      <a href="https://discord.gg/ENr3nurrx8" target="_blank" class="dropdownItem">Discord Community</a>
-                    </li>
-
-                    <li class="divider dark:border-t-gray-400" data-content="GITHUB"></li>
-                    <li>
-                      <a href="https://github.com/ccrma/webchuck-ide" target="_blank" class="dropdownItem">GitHub Repo</a>
-                    </li>
-                    <li>
-                      <a href="https://github.com/ccrma/webchuck-ide/issues/new" target="_blank" class="dropdownItem">Report an Issue</a>
+                    <li role="separator">
+                      <a href="https://discord.gg/ENr3nurrx8" target="_blank" rel="noopener noreferrer" class="dropdownItem" role="menuitem">Discord Community</a>
                     </li>
 
-                    <li class="divider dark:border-t-gray-400" data-content="ABOUT"></li>
-                    <li>
-                      <button id="about-ide" class="dropdownItem">About IDE...</button>
+                    <li class="divider dark:border-t-gray-400" data-content="GITHUB" role="separator"></li>
+                    <li role="separator">
+                      <a href="https://github.com/ccrma/webchuck-ide" target="_blank" rel="noopener noreferrer" class="dropdownItem" role="menuitem">GitHub Repo</a>
+                    </li>
+                    <li role="separator">
+                      <a href="https://github.com/ccrma/webchuck-ide/issues/new" target="_blank" rel="noopener noreferrer" class="dropdownItem" role="menuitem">Report an Issue</a>
+                    </li>
+
+                    <li class="divider dark:border-t-gray-400" data-content="ABOUT" role="separator"></li>
+                    <li role="separator">
+                      <button id="about-ide" type="button" class="dropdownItem" role="menuitem">About IDE...</button>
                     </li>
 
                   </ul>
@@ -229,12 +229,12 @@
             <button id="shareCode" class="button border-2 border-blue-600 dark:border-blue-200 px-3 py-1 rounded-md font-medium ml-4 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 dark:focus-visible:ring-blue-200">Share</button>
           </div>
         </nav>
-      </div>
+      </header>
 
 
       <!-- CHUCK BAR -->
-      <div id="chuckBar" class="bg-orange-peach dark:bg-dark-4 flex items-center justify-start px-2 py-1 gap-2">
-          <div class="flex items-center gap-2 flex-shrink-0">
+      <nav id="chuckBar" class="bg-orange-peach dark:bg-dark-4 flex items-center justify-start px-2 py-1 gap-2" aria-label="ChucK controls">
+          <div class="flex items-center gap-2 flex-shrink-0" role="toolbar" aria-label="ChucK controls">
             <button id="webchuckButton" type="button" class="chuck-button h-10 font-semibold bg-orange text-white text-base px-3 enabled:hover:bg-orange-400 transition-all overflow-hidden truncate disabled:opacity-50" disabled>Loading...</button>
             <button id="micButton" type="button" class="chuck-button bg-[#CF68FF] disabled:opacity-50" title="Enable Microphone" aria-label="Enable Microphone" disabled>
               <svg viewBox="13 9 24 33" fill="none" class="w-5 h-5"><path d="M25 10.1667C22.3764 10.1667 20.25 12.2931 20.25 14.9167V24.4167C20.25 27.0402 22.3764 29.1667 25 29.1667C27.6236 29.1667 29.75 27.0402 29.75 24.4167V14.9167C29.75 12.2931 27.6236 10.1667 25 10.1667ZM15.6392 24.4167C14.6797 24.4167 13.9069 25.2681 14.062 26.2165C14.8377 30.966 18.6368 34.6909 23.4167 35.3763V38.6667C23.4167 39.5407 24.126 40.25 25 40.25C25.874 40.25 26.5834 39.5407 26.5834 38.6667V35.3763C31.3632 34.6909 35.1624 30.966 35.938 26.2165C36.0932 25.2681 35.3204 24.4167 34.3609 24.4167C33.5787 24.4167 32.9337 24.9923 32.8023 25.765C32.161 29.4937 28.9124 32.3333 25 32.3333C21.0876 32.3333 17.839 29.4937 17.1978 25.765C17.0664 24.9923 16.4229 24.4167 15.6392 24.4167Z" fill="white"/></svg>
@@ -252,17 +252,17 @@
               <svg viewBox="13 13 24 24" fill="none" class="w-5 h-5"><circle cx="25" cy="25" r="10" fill="#FF6868"/></svg>
             </button>
           </div>
-      </div>
+      </nav>
 
 
       <!-- APP -->
-      <div id="app">
+      <main id="app">
 
         <!-- Left -->
         <div id="app-left">
           <div id="fileExplorerPanel" class="h-full flex flex-col justify-start">
-            <div id="fileExplorerHeader" class="header h-10 justify-start flex-none border-b border-dark-d dark:border-dark-a drop-shadow-sm font-bold overflow-hidden whitespace-nowrap">
-              <div class="px-2">File Explorer</div>
+            <div id="fileExplorerHeader" class="header h-10 justify-start flex-none border-b drop-shadow-sm font-bold overflow-hidden whitespace-nowrap">
+              <h2 class="px-2 text-base font-bold">File Explorer</h2>
             </div>
             <div id="fileExplorerContainer">
               <div id="fileExplorer" class="absolute w-full h-full overflow-y-auto overflow-x-hidden"></div>
@@ -331,7 +331,7 @@
               <div id="SensorPanel" class="absolute w-full h-full p-2 pt-1">
                 <div class="pb-2 font-bold text-md">Mobile Only</div>
                 <div class="flex flex-wrap pb-1">
-                  <button id="gyroButton" class="toggle-button w-32 mr-2" disabled>Gryo: Off</button>
+                  <button id="gyroButton" class="toggle-button w-32 mr-2" disabled>Gyro: Off</button>
                   <div id="gyroLog" class="log-container sensorLog opacity-50 text-sm"></div>
                 </div>
                 <div class="flex flex-wrap pb-1">
@@ -370,7 +370,7 @@
                   </tbody>
                 </table>
               </div>
-              <div id="chuckNowStatus" class="shrink-0 whitespace-nowrap px-2 flex items-center justify-end gap-1 text-sm bg-sky-blue-300 dark:bg-dark border-t border-sky-blue-700 dark:border-dark-5" style="display: none; height: 30px;">
+              <div id="chuckNowStatus" class="shrink-0 whitespace-nowrap px-2 flex items-center justify-end gap-1 text-sm" style="display: none; height: 30px; background-color: var(--ide-bg, #DDEEFF); border-top: 1px solid var(--ide-border, #C9E0F7);">
                 <span class="text-orange font-mono"><b>now:</b></span>
                 <span id="chuckNowTime" class="font-mono text-dark-4 dark:text-light">00:00:00.00000</span>
               </div>
@@ -387,12 +387,12 @@
           </div>
         </div>
 
-      </div>
+      </main>
 
       <!-- MODALS -->
       <!-- More Examples Modal -->
-      <dialog class="modal modal-lg" id="more-examples-modal">
-        <h1 class="text-xl font-medium pb-2">ChucK Example Library</h1>
+      <dialog class="modal modal-lg" id="more-examples-modal" aria-labelledby="more-examples-heading">
+        <h2 id="more-examples-heading" class="text-xl font-medium pb-2">ChucK Example Library</h2>
         <div class="w-full p-2 border border-gray-200 bg-gray-50 rounded-t-xl dark:border-gray-600 dark:bg-dark-4 flex flex-col-reverse md:flex-row">
           <!-- Breadcrumbs -->
           <nav class="flex justify-left w-1/2 pl-2 pt-2 md:pt-0">
@@ -440,8 +440,8 @@
       </dialog>
 
       <!-- Settings Modal -->
-      <dialog class="modal" id="settings-modal">
-        <h1 class="text-xl font-medium pb-2">Settings</h1>
+      <dialog class="modal" id="settings-modal" aria-labelledby="settings-heading">
+        <h2 id="settings-heading" class="text-xl font-medium pb-2">Settings</h2>
         <!-- Setting Options-->
         <form class="flex flex-col gap-2 py-2 pr-7" method="dialog">
           <label class="form-label" for="chuck-version-select">ChucK version</label>
@@ -453,16 +453,16 @@
         </form>
         <!-- Close Settings -->
         <div class="flex gap-4 justify-end pt-4">
-          <button id="settings-close" class="button secondary">Cancel</button>
-          <button id="settings-apply" class="button primary">Reload</button>
+          <button id="settings-close" type="button" class="button secondary">Cancel</button>
+          <button id="settings-apply" type="button" class="button primary">Reload</button>
         </div>
       </dialog>
 
 
       <!-- Export to WebChucK Modal -->
-      <dialog class="modal" id="export-webchuck-modal">
+      <dialog class="modal" id="export-webchuck-modal" aria-labelledby="export-wc-heading">
         <form class="flex flex-col gap-2 py-2" method="dialog">
-          <h1 class="text-xl font-medium pb-2">Export to WebChucK</h1>
+          <h2 id="export-wc-heading" class="text-xl font-medium pb-2">Export to WebChucK</h2>
 
           <div>
             <label class="form-label" for="export-title">Title</label>
@@ -493,15 +493,16 @@
       </dialog>
 
       <!-- Share Code Modal -->
-      <dialog class="modal modal-sm" id="share-code-modal">
+      <dialog class="modal modal-sm" id="share-code-modal" aria-labelledby="share-code-heading">
         <form class="flex flex-col gap-2 py-2" method="dialog">
           <!-- display url to copy -->
+          <h2 id="share-code-heading" class="sr-only">Share Code</h2>
           <label class="form-label" for="share-code-url">Shareable URL</label>
           <input type="text" id="share-code-url" class="border px-2 py-1 rounded-md" readonly>
         </form>
         <div class="flex gap-4 justify-end pt-4">
-          <button id="share-code-close" class="button secondary">Close</button>
-          <button id="share-code-copy" class="button primary">Copy</button>
+          <button id="share-code-close" type="button" class="button secondary">Close</button>
+          <button id="share-code-copy" type="button" class="button primary">Copy</button>
         </div>
       </dialog>
     </div>

--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@
 
 
       <!-- CHUCK BAR -->
-      <nav id="chuckBar" class="bg-orange-peach dark:bg-dark-4 flex items-center justify-start px-2 py-1 gap-2" aria-label="ChucK controls">
+      <nav id="chuckBar" class="flex items-center justify-start px-2 py-1 gap-2" aria-label="ChucK controls">
           <div class="flex items-center gap-2 flex-shrink-0" role="toolbar" aria-label="ChucK controls">
             <button id="webchuckButton" type="button" class="chuck-button h-10 font-semibold bg-orange text-white text-base px-3 enabled:hover:bg-orange-400 transition-all overflow-hidden truncate disabled:opacity-50" disabled>Loading...</button>
             <button id="micButton" type="button" class="chuck-button bg-[#CF68FF] disabled:opacity-50" title="Enable Microphone" aria-label="Enable Microphone" disabled>
@@ -403,7 +403,7 @@
           <div class="justify-right w-full h-10 md:w-1/2 relative">
             <input id="more-examples-search" type="text" role="combobox" aria-autocomplete="list" aria-expanded="false"
               aria-controls="autocomplete-list" aria-activedescendant=""
-              class="w-full h-full py-2 pl-11 pr-3 border border-gray-300 rounded-md dark:bg-dark-4"
+              class="form-input h-full !pl-11 !pr-3"
               placeholder="Search..." aria-label="Search examples">
             <div class="absolute left-3 top-1/2 transform -translate-y-1/2">
               <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="h-6 w-6 text-gray-500">
@@ -498,7 +498,7 @@
           <!-- display url to copy -->
           <h2 id="share-code-heading" class="sr-only">Share Code</h2>
           <label class="form-label" for="share-code-url">Shareable URL</label>
-          <input type="text" id="share-code-url" class="border px-2 py-1 rounded-md" readonly>
+          <input type="text" id="share-code-url" class="form-input" readonly>
         </form>
         <div class="flex gap-4 justify-end pt-4">
           <button id="share-code-close" type="button" class="button secondary">Close</button>

--- a/src/components/chuckBar/recorder.ts
+++ b/src/components/chuckBar/recorder.ts
@@ -20,6 +20,13 @@ export enum RecordState {
     armed = 2,
 }
 
+// Inline SVG icons for record button states
+const RecordButtonIcon = {
+    record: `<svg viewBox="13 13 24 24" fill="none" class="w-5 h-5"><circle cx="25" cy="25" r="10" fill="#FF6868"/></svg>`,
+    stop: `<svg viewBox="15 15 20 20" fill="none" class="w-5 h-5"><path d="M17 19C17 17.8954 17.8954 17 19 17H31C32.1046 17 33 17.8954 33 19V31C33 32.1046 32.1046 33 31 33H19C17.8954 33 17 32.1046 17 31V19Z" fill="white"/></svg>`,
+    armed: `<svg viewBox="3 3 44 44" fill="none" class="w-5 h-5"><circle cx="25" cy="25" r="20" fill="white"/><circle cx="25" cy="25" r="7" fill="#FF6868"/></svg>`,
+};
+
 export default class Recorder {
     public static state: RecordState = RecordState.stopped;
     public static recordButton: HTMLButtonElement;
@@ -29,6 +36,11 @@ export default class Recorder {
     private static stream: MediaStreamAudioDestinationNode;
     private static recorder: MediaRecorder;
     private static buffer: Blob[];
+
+    private static setRecordButton(icon: string, bg: string) {
+        Recorder.recordButton.innerHTML = icon;
+        Recorder.recordButton.style.backgroundColor = bg;
+    }
 
     constructor(recordButton: HTMLButtonElement) {
         Recorder.recordButton = recordButton;
@@ -116,6 +128,7 @@ export default class Recorder {
     static startRecording() {
         Recorder.state = RecordState.recording;
         Console.print("\x1b[31mrecording...\x1b[0m"); // Print in red
+        Recorder.setRecordButton(RecordButtonIcon.stop, "#FF6868");
         Recorder.recordButton.classList.remove("ring-2", "ring-red-500");
 
         Recorder.playButton.removeEventListener(
@@ -128,6 +141,7 @@ export default class Recorder {
     static stopRecording() {
         Recorder.state = RecordState.stopped;
         Console.print("recording stopped...");
+        Recorder.setRecordButton(RecordButtonIcon.record, "white");
         Recorder.recordButton.classList.remove("ring-2", "ring-red-500");
 
         Recorder.recorder.stop();
@@ -143,6 +157,7 @@ export default class Recorder {
 
     static disarmRecorder() {
         Recorder.state = RecordState.stopped;
+        Recorder.setRecordButton(RecordButtonIcon.record, "white");
         Recorder.recordButton.classList.remove("ring-2", "ring-red-500");
         Recorder.playButton.removeEventListener(
             "click",

--- a/src/components/chuckBar/recorder.ts
+++ b/src/components/chuckBar/recorder.ts
@@ -20,16 +20,9 @@ export enum RecordState {
     armed = 2,
 }
 
-enum RecordButtonImage {
-    stop = "img/stop-button.svg",
-    record = "img/record-button.svg",
-    armed = "img/armed-button.svg",
-}
-
 export default class Recorder {
     public static state: RecordState = RecordState.stopped;
     public static recordButton: HTMLButtonElement;
-    public static recordImage: HTMLImageElement;
     public static playButton: HTMLButtonElement;
     public static removeButton: HTMLButtonElement;
 
@@ -43,10 +36,6 @@ export default class Recorder {
         Recorder.recordButton.addEventListener("click", async () => {
             Recorder.recordPressed();
         });
-        Recorder.recordImage = document.getElementById(
-            "recordImage"
-        )! as HTMLImageElement;
-
         // Get references to Chuck Buttons
         Recorder.playButton = document.getElementById(
             "playButton"
@@ -127,7 +116,7 @@ export default class Recorder {
     static startRecording() {
         Recorder.state = RecordState.recording;
         Console.print("\x1b[31mrecording...\x1b[0m"); // Print in red
-        Recorder.recordImage.src = RecordButtonImage.stop;
+        Recorder.recordButton.classList.remove("ring-2", "ring-red-500");
 
         Recorder.playButton.removeEventListener(
             "click",
@@ -139,7 +128,7 @@ export default class Recorder {
     static stopRecording() {
         Recorder.state = RecordState.stopped;
         Console.print("recording stopped...");
-        Recorder.recordImage.src = RecordButtonImage.record;
+        Recorder.recordButton.classList.remove("ring-2", "ring-red-500");
 
         Recorder.recorder.stop();
     }
@@ -147,14 +136,14 @@ export default class Recorder {
     static armRecorder() {
         Recorder.state = RecordState.armed;
         Console.print("armed for recording...");
-        Recorder.recordImage.src = RecordButtonImage.armed;
+        Recorder.recordButton.classList.add("ring-2", "ring-red-500");
 
         Recorder.playButton.addEventListener("click", Recorder.startRecording);
     }
 
     static disarmRecorder() {
         Recorder.state = RecordState.stopped;
-        Recorder.recordImage.src = RecordButtonImage.record;
+        Recorder.recordButton.classList.remove("ring-2", "ring-red-500");
         Recorder.playButton.removeEventListener(
             "click",
             Recorder.startRecording

--- a/src/components/examples/moreExamples.ts
+++ b/src/components/examples/moreExamples.ts
@@ -126,22 +126,26 @@ export default class MoreExamples {
 
         // More Examples Search
         MoreExamples.moreExamplesSearch.addEventListener("input", () => {
-            MoreExamples.searchExamples(MoreExamples.moreExamplesSearch.value);
+            const query = MoreExamples.moreExamplesSearch.value;
+            MoreExamples.searchExamples(query);
             MoreExamples.autoCompleteSelectedIndex = -1;
             MoreExamples.moreExamplesSearch.setAttribute("aria-activedescendant", "");
-            if (!MoreExamples.autoCompleteVisible) {
-                MoreExamples.moreExamplesAutoComplete.classList.remove(
-                    "hidden"
-                );
+            const hasResults = query.trim() !== "" && MoreExamples.moreExamplesAutoCompleteList.children.length > 0;
+            if (hasResults && !MoreExamples.autoCompleteVisible) {
+                MoreExamples.moreExamplesAutoComplete.classList.remove("hidden");
                 MoreExamples.moreExamplesSearch.setAttribute("aria-expanded", "true");
                 MoreExamples.autoCompleteVisible = true;
+            } else if (!hasResults && MoreExamples.autoCompleteVisible) {
+                MoreExamples.moreExamplesAutoComplete.classList.add("hidden");
+                MoreExamples.moreExamplesSearch.setAttribute("aria-expanded", "false");
+                MoreExamples.autoCompleteVisible = false;
             }
         });
         MoreExamples.moreExamplesSearch.addEventListener(
             "click",
             (e: MouseEvent) => {
                 e.stopPropagation();
-                if (!MoreExamples.autoCompleteVisible) {
+                if (!MoreExamples.autoCompleteVisible && MoreExamples.moreExamplesSearch.value.trim() !== "") {
                     MoreExamples.moreExamplesAutoComplete.classList.remove(
                         "hidden"
                     );

--- a/src/components/fileExplorer/projectFile.ts
+++ b/src/components/fileExplorer/projectFile.ts
@@ -6,16 +6,15 @@
 // date:   January 2024
 //------------------------------------------------------------------
 
-import { isPlaintextFile } from "webchuck/dist/utils";
+import { isPlaintextFile } from "@/utils/fileLoader";
 import Editor from "@/components/editor/monaco/editor";
 
 export default class ProjectFile {
-    private readonly filename: string;
+    private filename: string;
     private data: string | Uint8Array;
-    private readonly isCk: boolean;
-    private readonly isPlaintext: boolean;
+    private isCk: boolean;
+    private isPlaintext: boolean;
     private active: boolean;
-    // TODO: do we need file extension?
 
     constructor(filename: string, data: string | Uint8Array) {
         this.filename = filename;
@@ -27,7 +26,6 @@ export default class ProjectFile {
     loadFile() {
         if (!this.active && this.isPlaintext) {
             Editor.setFileName(this.filename);
-            // TODO: Set Monaco Editor Language (js, html etc.)
             Editor.setEditorCode(this.data as string);
             this.active = true;
         }
@@ -35,7 +33,6 @@ export default class ProjectFile {
     unloadFile() {
         if (this.active) {
             this.data = Editor.getEditorCode();
-            // TODO: save data to file system (future indexDB)
             this.active = false;
         }
     }

--- a/src/components/inputPanel/hidPanel.ts
+++ b/src/components/inputPanel/hidPanel.ts
@@ -60,7 +60,7 @@ export default class HidPanel {
                 HidPanel.setMonitorState();
             },
             () => {
-                hid.disableKeyboard;
+                hid.disableKeyboard();
                 document.removeEventListener("keydown", logKeyEvent);
                 document.removeEventListener("keyup", logKeyEvent);
                 HidPanel.keyboardActive = false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -132,3 +132,14 @@ class Main {
 // Main entry point
 const main = new Main();
 main.init();
+
+// Suppress Monaco's harmless CancellationError from its clipboard workaround.
+// Monaco logs these via its internal logService.error(), which calls console.error().
+// See: https://github.com/compiler-explorer/compiler-explorer/issues/7181
+const _consoleError = console.error;
+console.error = (...args: any[]) => {
+    if (args.some((a) => a?.name === "Canceled" && a?.message === "Canceled")) {
+        return;
+    }
+    _consoleError.apply(console, args);
+};

--- a/src/services/export/exportChuck.ts
+++ b/src/services/export/exportChuck.ts
@@ -1,6 +1,5 @@
 import NavBar from "@/components/navbar/navbar";
 import ProjectSystem from "@/components/fileExplorer/projectSystem";
-import JSZip from "jszip";
 
 const exportChuckButton =
     document.querySelector<HTMLButtonElement>("#exportChuck")!;
@@ -42,7 +41,8 @@ function exportSingleFile() {
 /**
  * Export all project files as a .zip
  */
-function exportProjectFiles() {
+async function exportProjectFiles() {
+    const { default: JSZip } = await import("jszip");
     const projectFiles = ProjectSystem.getProjectFiles();
     const zip = new JSZip();
     projectFiles.forEach((file) => {

--- a/src/services/export/exportWebchuck.ts
+++ b/src/services/export/exportWebchuck.ts
@@ -1,4 +1,3 @@
-import JSZip from "jszip";
 import ProjectSystem from "@/components/fileExplorer/projectSystem";
 import Editor from "@/components/editor/monaco/editor";
 import { getGlobalVariables } from "@/utils/chuckPreprocess";
@@ -163,7 +162,7 @@ function exportSingleWCFile(wc_html: Document) {
  * Export all project files as a .zip
  * @param wc_html webchuck html document
  */
-function exportProjectWCFiles(
+async function exportProjectWCFiles(
     title: string,
     mainChuckFile: string,
     wc_html: Document,
@@ -172,6 +171,7 @@ function exportProjectWCFiles(
     if (title === "") {
         title = mainChuckFile.split(".")[0];
     }
+    const { default: JSZip } = await import("jszip");
     const zip = new JSZip();
     zip.file("index.html", wc_html.documentElement.outerHTML);
     projectFiles.forEach((file: any) => {

--- a/src/services/shareCode.ts
+++ b/src/services/shareCode.ts
@@ -47,10 +47,13 @@ export function initShareCode() {
     });
 
     // Copy URL
-    shareCodeCopyButton.addEventListener("click", () => {
-        // copy to clipboard
-        shareCodeURLField.select();
-        document.execCommand("copy");
+    shareCodeCopyButton.addEventListener("click", async () => {
+        try {
+            await navigator.clipboard.writeText(shareCodeURLField.value);
+        } catch {
+            shareCodeURLField.select();
+            document.execCommand("copy");
+        }
         shareCodeURLField.setSelectionRange(0, 0);
 
         shareCodeCopyButton.textContent = "Copied!";

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,14 +4,96 @@
 @tailwind components;
 @tailwind utilities;
 
+/* IDE Theme: CSS variable colors for structural elements.
+   Light values are baked as var() fallbacks; dark overrides below.
+   A full theme system can later replace both with runtime setProperty(). */
+:root.dark {
+    --ide-bg: #222222;
+    --ide-bg-alt: #333333;
+    --ide-text: #EEEEEE;
+    --ide-text-muted: #AAAAAA;
+    --ide-accent: #FF8833;
+    --ide-accent-hover: #ffa64d;
+    --ide-border: #555555;
+    --ide-editor-bg: #1e1e1e;
+    --ide-console-bg: #222222;
+}
+
+body {
+    background-color: var(--ide-bg, #DDEEFF);
+    color: var(--ide-text, #555555);
+}
+
+/* Theme-aware scrollbars */
+* {
+    scrollbar-width: thin;
+    scrollbar-color: var(--ide-border, #C9E0F7) var(--ide-bg, #DDEEFF);
+}
+
+*::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+*::-webkit-scrollbar-track {
+    background: var(--ide-bg, #DDEEFF);
+}
+
+*::-webkit-scrollbar-thumb {
+    background-color: var(--ide-border, #C9E0F7);
+    border-radius: 4px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+    background-color: var(--ide-text-muted, #8b8f96);
+}
+
+#app-left {
+    background-color: var(--ide-bg, #DDEEFF);
+}
+
+.header {
+    background-color: var(--ide-bg-alt, #DDEEFF);
+    border-color: var(--ide-border, #C9E0F7);
+}
+
+#vmMonitorContainer {
+    background-color: var(--ide-bg, #DDEEFF);
+}
+
+#inputPanel {
+    background-color: var(--ide-bg, #DDEEFF);
+}
+
+#GUIContainer,
+#HIDContainer,
+#SensorContainer {
+    background-color: var(--ide-bg, #DDEEFF);
+}
+
+#visualizerContainer {
+    background-color: var(--ide-console-bg, #ffffff);
+}
+
+#console {
+    background-color: var(--ide-console-bg, #ffffff);
+}
+
+/* Theme-aware accent color for toggles and selected items */
+.text-accent {
+    color: var(--ide-accent, #FF8833);
+}
+
 /* WEBCHUCK IDE LAYOUT */
 #navbarWrapper {
+    background-color: var(--ide-bg-alt, #DDEEFF);
     grid-area: nav;
     user-select: none;
     -webkit-touch-callout: none;
 }
 
 #chuckBar {
+    background-color: var(--ide-bg, #DDEEFF);
     grid-area: chuckBar;
 }
 
@@ -131,11 +213,19 @@
 }
 
 .dropdownItem {
-    @apply block w-full text-left font-medium px-4 py-2 hover:bg-gray-100 focus-visible:bg-gray-100 dark:hover:bg-dark-5 dark:focus-visible:bg-dark-5 dark:hover:text-light dark:focus-visible:text-light focus:outline-none;
+    @apply block w-full text-left font-medium px-4 py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-sky-blue-800;
+    color: var(--ide-text, #555);
+}
+.dropdownItem:hover,
+.dropdownItem:focus-visible {
+    background-color: var(--ide-border, #ccc);
+    color: var(--ide-text, #555);
 }
 
 .dropdown {
-    @apply absolute z-40 bg-white divide-y divide-gray-100 max-h-96 rounded-lg shadow-md dark:bg-dark dark:divide-gray-700 ring-1 ring-black ring-opacity-5 focus:outline-none origin-top-left;
+    @apply absolute z-40 rounded-lg shadow-md ring-1 ring-black ring-opacity-5 focus:outline-none origin-top-left;
+    background-color: var(--ide-bg-alt, #ffffff);
+    border: 1px solid var(--ide-border, #ccc);
     animation: enter-transition 0.1s ease-in-out forwards;
 }
 
@@ -144,13 +234,19 @@
 }
 
 .nestedDropdown {
-    @apply absolute z-50 bg-white divide-y divide-gray-100 max-h-96 overflow-y-auto rounded-lg shadow-md dark:bg-dark dark:divide-gray-700 ring-1 ring-black ring-opacity-5 focus:outline-none origin-top-left left-full top-0 -mt-2;
+    @apply absolute z-50 max-h-96 overflow-y-auto rounded-lg shadow-md ring-1 ring-black ring-opacity-5 focus:outline-none origin-top-left left-full top-0 -mt-2;
+    background-color: var(--ide-bg-alt, #ffffff);
+    border: 1px solid var(--ide-border, #ccc);
     animation: enter-transition 0.1s ease-in-out forwards;
 }
 
 /* EXAMPLES */
 #autocomplete-list li {
-    @apply px-3 py-2 cursor-pointer hover:bg-opacity-50 focus-visible:bg-opacity-50 hover:bg-sky-blue-100 focus-visible:bg-sky-blue-100 focus:outline-none dark:hover:bg-dark-5 dark:focus-visible:bg-dark-5;
+    @apply px-3 py-2 cursor-pointer focus:outline-none;
+}
+#autocomplete-list li:hover,
+#autocomplete-list li:focus-visible {
+    background-color: var(--ide-border, #ccc);
 }
 
 #autocomplete-list pre {
@@ -166,15 +262,21 @@
 }
 
 .breadcrumb-item {
-    @apply inline-flex items-center text-sm font-medium text-gray-700 dark:text-gray-400;
+    @apply inline-flex items-center text-sm font-medium;
+    color: var(--ide-text-muted, #555);
 }
 
-.breadcrumb-item.hover {
-    @apply hover:text-orange;
+.breadcrumb-item.hover:hover {
+    color: var(--ide-accent, #FF8833);
 }
 
 .explorer-item {
-    @apply px-3 py-2 cursor-pointer text-lg rounded-lg text-orange hover:bg-opacity-50 focus-visible:bg-opacity-50 hover:bg-sky-blue-100 focus-visible:bg-sky-blue-100 focus:outline-none dark:hover:bg-dark-5 dark:focus-visible:bg-dark-5;
+    @apply px-3 py-2 cursor-pointer text-lg focus:outline-none;
+    color: var(--ide-accent, #FF8833);
+}
+.explorer-item:hover,
+.explorer-item:focus-visible {
+    background-color: var(--ide-border, #ccc);
 }
 
 .explorer-item.folder {
@@ -205,11 +307,16 @@
 }
 
 .fileExplorerEntry {
-    @apply flex items-center w-full relative hover:bg-[#ebeae8] focus-visible:bg-[#ebeae8] dark:hover:bg-dark-5 dark:focus-visible:bg-dark-5 hover:cursor-pointer whitespace-nowrap focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-600 dark:focus-visible:ring-blue-200;
+    @apply flex items-center w-full relative hover:cursor-pointer whitespace-nowrap focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-600 dark:focus-visible:ring-blue-200;
+}
+
+.fileExplorerEntry:hover,
+.fileExplorerEntry:focus-visible {
+    background-color: color-mix(in srgb, var(--ide-bg-alt, #FEFEFF) 50%, var(--ide-bg, #DDEEFF));
 }
 
 .fileExplorerEntry.active {
-    @apply bg-orange-peach dark:bg-dark-8;
+    background-color: var(--ide-bg-alt, #FCDEC0);
 }
 
 .fileExplorerItem {
@@ -286,9 +393,10 @@
     user-select: none;
 }
 
-#outputPanel>[role=tabpanel]:not(.hidden)+[role=tabpanel]:not(.hidden),
-#outputPanel>[role=tabpanel]:not(.hidden)+.hidden+[role=tabpanel]:not(.hidden) {
-    border-top: 1px solid rgb(68 68 68 / var(--tw-border-opacity, 1));
+/* Borders between visible output panels */
+#outputPanel > [role="tabpanel"]:not(.hidden) + [role="tabpanel"]:not(.hidden),
+#outputPanel > [role="tabpanel"]:not(.hidden) + .hidden + [role="tabpanel"]:not(.hidden) {
+    border-top: 1px solid var(--ide-border, #C9E0F7);
 }
 
 /* EDITOR */
@@ -342,13 +450,29 @@ span>.monaco-tokenized-source {
 }
 
 /* VM Monitor */
+
+#shredTable {
+    border-collapse: separate;
+    border-spacing: 0;
+}
+
+#shredTable thead {
+    border-color: var(--ide-border, #C9E0F7);
+}
+
+#shredTable thead tr th {
+    background-color: var(--ide-bg-alt, #DDEEFF);
+    border-color: var(--ide-border, #C9E0F7);
+}
+
 /* table header */
 table thead tr th {
     @apply px-4 bg-sky-blue-300 dark:bg-dark;
 }
 
 table tbody tr td {
-    @apply py-3 px-4 border-b border-sky-blue-700 dark:border-dark-5;
+    @apply py-3 px-4 border-b;
+    border-color: var(--ide-border, #C9E0F7);
 }
 
 td:nth-child(3) {
@@ -365,11 +489,24 @@ td:nth-child(4) {
 
 /* INPUT PANEL */
 .toggle-button {
-    @apply mr-2 mb-2 p-1 bg-transparent text-orange enabled:hover:text-white enabled:hover:bg-orange border border-orange rounded transition-all disabled:opacity-50;
+    @apply mr-2 mb-2 p-1 bg-transparent rounded transition-all disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2;
+    color: var(--ide-accent, #FF8833);
+    border: 1px solid var(--ide-accent, #FF8833);
+    --tw-ring-color: var(--ide-accent, #FF8833);
+}
+
+.toggle-button:enabled:hover {
+    background-color: var(--ide-accent, #FF8833);
+    color: white;
 }
 
 .toggle-button.active {
-    @apply bg-orange text-white enabled:hover:bg-orange-400 enabled:dark:hover:bg-orange-400;
+    background-color: var(--ide-accent, #FF8833);
+    color: white;
+}
+
+.toggle-button.active:enabled:hover {
+    background-color: var(--ide-accent-hover, #ffa64d);
 }
 
 /* GUI PANEL */
@@ -392,7 +529,9 @@ td:nth-child(4) {
 
 /* LOG CONSOLE */
 .log-container {
-    @apply px-2 py-1 mb-1 overflow-hidden border border-dark-d rounded-lg bg-white dark:bg-dark dark:border-dark-4;
+    @apply px-2 py-1 mb-1 overflow-hidden rounded-lg;
+    background-color: var(--ide-editor-bg, #FEFEFF);
+    border: 1px solid var(--ide-border, #CCCCCC);
 }
 
 .logMsg {
@@ -419,11 +558,14 @@ dialog {
 }
 
 dialog::backdrop {
-    @apply bg-white bg-opacity-50;
+    background-color: rgba(0, 0, 0, 0.3);
 }
 
 .modal {
-    @apply w-full px-8 py-6 rounded-lg dark:bg-dark dark:text-white;
+    @apply w-full px-8 py-6 rounded-lg;
+    background-color: var(--ide-bg-alt, #ffffff);
+    color: var(--ide-text, #555);
+    border: 1px solid var(--ide-border, #ccc);
     max-height: 75vh;
     max-width: 640px;
     animation: enter-transition 0.1s ease-in-out forwards;
@@ -432,7 +574,9 @@ dialog::backdrop {
 .modal form input,
 .modal form textarea,
 .modal form select {
-    @apply dark:bg-dark-4;
+    background-color: var(--ide-editor-bg, #fefeff);
+    color: var(--ide-text, #555);
+    border-color: var(--ide-border, #ccc);
 }
 
 .form-label {
@@ -440,11 +584,19 @@ dialog::backdrop {
 }
 
 .form-input {
-    @apply w-full border px-2 py-1 rounded-md focus-visible:outline-none focus-visible:border-blue-500 focus-visible:ring-1 focus-visible:ring-blue-600 dark:focus-visible:ring-blue-200;
+    @apply w-full px-2 py-1 rounded-md focus-visible:outline-none focus-visible:ring-1;
+    background-color: var(--ide-editor-bg, #fefeff);
+    color: var(--ide-text, #555);
+    border: 1px solid var(--ide-border, #ccc);
+    --tw-ring-color: var(--ide-accent, #FF8833);
 }
 
 .form-select {
-    @apply w-full border px-2 py-1 rounded-md focus-visible:outline-none focus-visible:border-blue-500 focus-visible:ring-1 focus-visible:ring-blue-600 dark:focus-visible:ring-blue-200;
+    @apply w-full px-2 py-1 rounded-md focus-visible:outline-none focus-visible:ring-1;
+    background-color: var(--ide-editor-bg, #fefeff);
+    color: var(--ide-text, #555);
+    border: 1px solid var(--ide-border, #ccc);
+    --tw-ring-color: var(--ide-accent, #FF8833);
 }
 
 .modal.modal-sm {
@@ -462,8 +614,8 @@ dialog::backdrop {
 
 .divider[data-content]::after,
 .divider-vert[data-content]::after {
-    background: #fff;
-    color: #bcc3ce;
+    background: var(--ide-bg-alt, #fff);
+    color: var(--ide-text-muted, #8b8f96);
     content: attr(data-content);
     display: inline-block;
     font-size: 0.8rem;
@@ -471,12 +623,8 @@ dialog::backdrop {
     transform: translateY(-0.85rem);
 }
 
-.dark .divider[data-content]::after {
-    background: #333;
-}
-
 .divider {
-    border-top: 0.06rem solid #e1e3e5;
+    border-top: 0.06rem solid var(--ide-border, #e1e3e5);
     height: 0.05rem;
     margin: 0.4rem 0.2rem 0.4rem 0;
 }
@@ -486,8 +634,11 @@ dialog::backdrop {
 }
 
 .resizer.hSplit {
-    @apply relative hover:bg-orange hover:transition hover:opacity-100 hover:h-2 hover:-top-1;
+    @apply relative hover:transition hover:opacity-100 hover:h-2 hover:-top-1;
     cursor: row-resize;
+}
+.resizer.hSplit:hover {
+    background-color: var(--ide-accent, #FF8833);
 }
 
 .hSplit::after {
@@ -496,8 +647,11 @@ dialog::backdrop {
 }
 
 .resizer.vSplit {
-    @apply relative hover:bg-orange hover:transition hover:opacity-100 hover:w-2 hover:-left-1 z-30;
+    @apply relative hover:transition hover:opacity-100 hover:w-2 hover:-left-1 z-30;
     cursor: col-resize;
+}
+.resizer.vSplit:hover {
+    background-color: var(--ide-accent, #FF8833);
 }
 
 .vSplit::after {
@@ -507,7 +661,7 @@ dialog::backdrop {
 
 .vSplit.active,
 .hSplit.active {
-    @apply bg-orange;
+    background-color: var(--ide-accent, #FF8833);
 }
 
 .resizer {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -93,7 +93,7 @@ body {
 }
 
 #chuckBar {
-    background-color: var(--ide-bg, #DDEEFF);
+    background-color: var(--ide-bg, #FFE5C4);
     grid-area: chuckBar;
 }
 
@@ -218,14 +218,14 @@ body {
 }
 .dropdownItem:hover,
 .dropdownItem:focus-visible {
-    background-color: var(--ide-border, #ccc);
+    background-color: var(--ide-border, #f3f4f6);
     color: var(--ide-text, #555);
 }
 
 .dropdown {
     @apply absolute z-40 rounded-lg shadow-md ring-1 ring-black ring-opacity-5 focus:outline-none origin-top-left;
     background-color: var(--ide-bg-alt, #ffffff);
-    border: 1px solid var(--ide-border, #ccc);
+    border: 1px solid var(--ide-border, #f3f4f6);
     animation: enter-transition 0.1s ease-in-out forwards;
 }
 
@@ -236,7 +236,7 @@ body {
 .nestedDropdown {
     @apply absolute z-50 max-h-96 overflow-y-auto rounded-lg shadow-md ring-1 ring-black ring-opacity-5 focus:outline-none origin-top-left left-full top-0 -mt-2;
     background-color: var(--ide-bg-alt, #ffffff);
-    border: 1px solid var(--ide-border, #ccc);
+    border: 1px solid var(--ide-border, #f3f4f6);
     animation: enter-transition 0.1s ease-in-out forwards;
 }
 
@@ -246,7 +246,7 @@ body {
 }
 #autocomplete-list li:hover,
 #autocomplete-list li:focus-visible {
-    background-color: var(--ide-border, #ccc);
+    background-color: var(--ide-border, #f3f4f6);
 }
 
 #autocomplete-list pre {

--- a/src/utils/fileLoader.ts
+++ b/src/utils/fileLoader.ts
@@ -11,6 +11,18 @@ export interface File {
     data: string | Uint8Array;
 }
 
+const textFileExtensions = ["ck", "txt", "csv", "json", "xml", "html", "js"];
+
+/**
+ * Check if a file is a plaintext file based on its extension.
+ * Local copy of the utility from webchuck/dist/utils so it works
+ * in both WebChucK and WebChuGL modes.
+ */
+export function isPlaintextFile(filename: string): boolean {
+    const ext = filename.split(".").pop();
+    return textFileExtensions.includes(ext ?? "");
+}
+
 /**
  * Load a text file, can be a .ck file or a generic plaintext file
  * @param url


### PR DESCRIPTION
CSS: add CSS variables for theming, remove duplicate rules
fix: hidPanel() missing parens, Gyro typo, Monaco CancellationError (see [here](https://github.com/compiler-explorer/compiler-explorer/issues/7181), suppressing this error is the way to go)
dropdown: hover-to-switch, keyboard nav, positioning fixes (these changes are to follow dropdown standards)
misc: lazy-load JSZip, modern clipboard API, local isPlaintextFile