### PR TITLE
UI responsive mobile layout fix

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -51,7 +51,7 @@
             "splitH2"
             "app-right";
         grid-template-rows: 5fr 2px 5fr;
-        grid-template-columns: 100%;
+        grid-template-columns: 100% !important;
     }
 
     #chuck-bar {


### PR DESCRIPTION
Fix https://github.com/ccrma/webchuck-ide/issues/54 by isolating mobile styles and desktop styles for #app. Make columns 100% !important